### PR TITLE
Fixed leaked global/numbers undefined

### DIFF
--- a/www/SMS.js
+++ b/www/SMS.js
@@ -42,8 +42,9 @@ safesmsExport.enableIntercept = function(on_off, successCallback, failureCallbac
 };
 
 safesmsExport.sendSMS = function(address, text, successCallback, failureCallback) {
+	var numbers;
 	if( Object.prototype.toString.call( address ) === '[object Array]' ) {
-		// ok
+		numbers = address;
 	} else if(typeof address === 'string') {
 		numbers = [ address ];
 	} else {


### PR DESCRIPTION
Currently if an array of numbers is passed in, an error `numbers is undefined` will be thrown. This fixes the issue