### PR TITLE
Used PhoneNumberUtils.compare to compare phone numbers instead of string comparison.

### DIFF
--- a/src/android/SMSPlugin.java
+++ b/src/android/SMSPlugin.java
@@ -16,6 +16,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.telephony.SmsManager;
 import android.telephony.SmsMessage;
+import android.telephony.PhoneNumberUtils;
 import android.util.Log;
 
 import java.security.MessageDigest;
@@ -250,7 +251,7 @@ extends CordovaPlugin {
             } else if (fread > -1) {
                 matchFilter = (fread == cur.getInt(cur.getColumnIndex(READ)));
             } else if (faddress.length() > 0) {
-                matchFilter = faddress.equals(cur.getString(cur.getColumnIndex(ADDRESS)).trim());
+                matchFilter = PhoneNumberUtils.compare(faddress, cur.getString(cur.getColumnIndex(ADDRESS)).trim());
             } else if (fcontent.length() > 0) {
                 matchFilter = fcontent.equals(cur.getString(cur.getColumnIndex(BODY)).trim());
             } else {
@@ -428,7 +429,7 @@ extends CordovaPlugin {
                 int read = cur.getInt(cur.getColumnIndex(READ));
                 boolean matchRead = fread > -1 && fread == read;
                 String address = cur.getString(cur.getColumnIndex(ADDRESS)).trim();
-                boolean matchAddr = faddress.length() > 0 && address.equals(faddress);
+                boolean matchAddr = faddress.length() > 0 && PhoneNumberUtils.compare(faddress, address);
                 String body = cur.getString(cur.getColumnIndex(BODY)).trim();
                 boolean matchContent = fcontent.length() > 0 && body.equals(fcontent);
                 if (!matchId && !matchRead && !matchAddr && !matchContent) continue;


### PR DESCRIPTION
With only string comparison, numbers 123456789 and +XX123456789 does not match while they should as +XX is the country code. Also formatted and unformatted numbers should match, e.g. 123456789 and 1234 56789 are same. PhoneNumberUtils.compare is made for this purpose only. listSMS is tested while I didn't test the delete call, it should work as well.