### PR TITLE
Fix: can now use non-zero indexFrom values in listSMS for pagination

### DIFF
--- a/src/android/SMSPlugin.java
+++ b/src/android/SMSPlugin.java
@@ -258,10 +258,9 @@ extends CordovaPlugin {
                 matchFilter = true;
             }
             if (! matchFilter) continue;
-            
-            if (i < indexFrom) continue;
-            if (i >= indexFrom + maxCount) break;
             ++i;
+            if (i < indexFrom) continue;
+            if (i > indexFrom + maxCount) break; 
 
             if ((json = this.getJsonFromCursor(cur)) == null) {
                 callbackContext.error("failed to get json from cursor");

--- a/src/android/SMSPlugin.java
+++ b/src/android/SMSPlugin.java
@@ -259,7 +259,7 @@ extends CordovaPlugin {
             }
             if (! matchFilter) continue;
             ++i;
-            if (i < indexFrom) continue;
+            if (i <= indexFrom) continue;
             if (i > indexFrom + maxCount) break; 
 
             if ((json = this.getJsonFromCursor(cur)) == null) {


### PR DESCRIPTION
A Fix for https://github.com/floatinghotpot/cordova-plugin-sms/issues/63 and https://github.com/floatinghotpot/cordova-plugin-sms/issues/35

The indexFrom parameter in listSMS can now be used to select the starting index for the messages you want returned.

Ex. if indexFrom = 1, it will start by returning the 2nd message.